### PR TITLE
Handling empty Form parameter values

### DIFF
--- a/src/main/java/com/adobe/ags/curly/controller/ActionRunner.java
+++ b/src/main/java/com/adobe/ags/curly/controller/ActionRunner.java
@@ -381,6 +381,13 @@ public class ActionRunner implements Runnable {
                 List<String> newParamValues = newValues.get(paramNameProperty.get());
                 for (int i = 0; i < paramValues.size(); i++) {
                     String newParamValue = newParamValues != null && newParamValues.size() > i && newParamValues.get(i) != null ? newParamValues.get(i) : paramValues.get(i);
+               
+                    // fix for removing JCR values (setting them to an empty
+					// string deletes them from the JCR)
+					if (null == newParamValue) {
+						newParamValue = new String("");
+					}
+                    
                     newParamValue = newParamValue.replaceAll(variableNameMatchPattern, variableValue);
                     if (newParamName.contains("/") && newParamValue.equals("@" + newParamName)) {
                         // The upload name should actually be the file name, not the full path of the file.

--- a/src/main/java/com/adobe/ags/curly/controller/ActionRunner.java
+++ b/src/main/java/com/adobe/ags/curly/controller/ActionRunner.java
@@ -383,10 +383,10 @@ public class ActionRunner implements Runnable {
                     String newParamValue = newParamValues != null && newParamValues.size() > i && newParamValues.get(i) != null ? newParamValues.get(i) : paramValues.get(i);
                
                     // fix for removing JCR values (setting them to an empty
-					// string deletes them from the JCR)
-					if (null == newParamValue) {
-						newParamValue = new String("");
-					}
+                    // string deletes them from the JCR)
+                    if (null == newParamValue) {
+                    	newParamValue = new String("");
+                    }
                     
                     newParamValue = newParamValue.replaceAll(variableNameMatchPattern, variableValue);
                     if (newParamName.contains("/") && newParamValue.equals("@" + newParamName)) {


### PR DESCRIPTION
This minor change allows empty parameters, which lets us set and unset JCR values.
This disables a user's login, for example:
-FdisableUser=lockedOut ${server}${userPath}

And this re-enables them:
-FdisableUser= ${server}${userPath}